### PR TITLE
fix pathname2url import issue

### DIFF
--- a/octoprice_main_inky.py
+++ b/octoprice_main_inky.py
@@ -16,6 +16,7 @@ import sqlite3
 import datetime
 import pytz
 import time
+from urllib.request import pathname2url
 
 ##  -- Detect display type automatically
 try:


### PR DESCRIPTION
Somehow this line is missing - not sure how it can have been working without. Perhaps it's a Python version thing...